### PR TITLE
require cl at compile time

### DIFF
--- a/multi-web-mode.el
+++ b/multi-web-mode.el
@@ -34,6 +34,9 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (require 'cl))
+
 (defvar mweb-mode-map
   (let ((mweb-mode-map (make-sparse-keymap)))
     (define-key mweb-mode-map (kbd "M-<f11>") 'mweb-set-default-major-mode)


### PR DESCRIPTION
This allows byte-compiling the file when user wants to install it compiled.
